### PR TITLE
Skip creator when compiling reviews

### DIFF
--- a/lib/pull.js
+++ b/lib/pull.js
@@ -11,6 +11,7 @@ class Pull {
         this.checks = {};
         this.headRepoId = payload.pull_request.head.repo.id;
         this.baseRepoId = payload.pull_request.base.repo.id;
+        this.creator = payload.pull_request.user.login;
     }
 
     /**
@@ -55,18 +56,20 @@ class Pull {
                 const user = element.user.login;
                 const date = element.submitted_at;
                 const state = element.state;
-
-                if (typeof (compiled[user]) !== 'undefined') {
-                    if (date > compiled[user].date) {
+                // Creators reviews do not count since they cannot approve or reject their own PR, only comment
+                if (user !== this.creator) {
+                    if (typeof (compiled[user]) !== 'undefined') {
+                        if (date > compiled[user].date) {
+                            compiled[user] = {
+                                date: date,
+                                state: state
+                            }
+                        }
+                    } else {
                         compiled[user] = {
                             date: date,
                             state: state
                         }
-                    }
-                } else {
-                    compiled[user] = {
-                        date: date,
-                        state: state
                     }
                 }
             });


### PR DESCRIPTION
If the creator of a pull request makes a top level comment on their own PR, then the "reviews required" check will never pass.

This pull request remedies that by skipping the creator of a PR when compiling the reviews.

Also submitted upstream: https://github.com/squalrus/merge-bot/pull/63